### PR TITLE
Fix 3D tilt lag, glow clipping, and add RepoRover AI tag

### DIFF
--- a/next-portfolio/src/app/globals.css
+++ b/next-portfolio/src/app/globals.css
@@ -227,7 +227,6 @@
 
 .tilt-stage {
   transform-style: preserve-3d;
-  will-change: transform;
 }
 
 .tilt-layer {

--- a/next-portfolio/src/components/AboutSection.tsx
+++ b/next-portfolio/src/components/AboutSection.tsx
@@ -17,7 +17,7 @@ export function AboutSection() {
     : `https://${personal.website}`;
 
   return (
-    <section id="about" className="section-shell">
+    <section id="about" className="section-shell" style={{ overflow: 'visible', contentVisibility: 'visible' }}>
       <div ref={reveal} className="reveal space-y-8">
         <SectionHeading
           tag="about"
@@ -27,11 +27,12 @@ export function AboutSection() {
 
         <div
           className="grid gap-8 lg:grid-cols-2 lg:items-stretch"
-          style={{ perspective: "1400px" }}
+          style={{ perspective: "1400px", overflow: "visible" }}
         >
           {/* Bio */}
           <div className="flex flex-col gap-6">
-            <div ref={tiltRef} className="card tilt-stage flex-1">
+            <div ref={tiltRef} className="tilt-stage flex-1">
+              <div className="card h-full">
               <p
                 className="tilt-layer leading-relaxed text-[var(--text)]"
                 style={{ transform: "translateZ(10px)" }}
@@ -44,10 +45,12 @@ export function AboutSection() {
               >
                 {personal.about.detailed}
               </p>
+              </div>
             </div>
 
             <div className="grid gap-4 sm:grid-cols-2">
-              <div ref={tiltRef} className="card tilt-stage">
+              <div ref={tiltRef} className="tilt-stage">
+                <div className="card">
                 <p
                   className="tilt-layer font-mono text-xs text-[var(--accent)]"
                   style={{ transform: "translateZ(14px)" }}
@@ -66,8 +69,10 @@ export function AboutSection() {
                 >
                   Quality engineering, test automation, and building AI/ML-powered products with measurable impact.
                 </p>
+                </div>
               </div>
-              <div ref={tiltRef} className="card tilt-stage">
+              <div ref={tiltRef} className="tilt-stage">
+                <div className="card">
                 <p
                   className="tilt-layer font-mono text-xs text-[var(--accent)]"
                   style={{ transform: "translateZ(14px)" }}
@@ -86,6 +91,7 @@ export function AboutSection() {
                 >
                   Bias for action, fast iterations, clean API boundaries, and crisp documentation.
                 </p>
+                </div>
               </div>
             </div>
           </div>
@@ -93,7 +99,8 @@ export function AboutSection() {
           {/* Photo + Terminal column */}
           <div className="flex flex-col gap-4 h-full">
           {/* Photo card */}
-          <div ref={photoTiltRef} className="card tilt-stage overflow-hidden p-2 flex-1 min-h-96">
+          <div ref={photoTiltRef} className="tilt-stage flex-1 min-h-96">
+            <div className="card overflow-hidden p-2 h-full">
             <div className="relative h-full min-h-48 rounded-lg overflow-hidden">
               <Image
                 src="/images/eli-photo-1-optimized.jpg"
@@ -103,13 +110,15 @@ export function AboutSection() {
                 sizes="(max-width: 640px) calc(100vw - 3rem), (max-width: 1024px) 90vw, 440px"
               />
             </div>
+            </div>
           </div>
 
           {/* Terminal card */}
           <div
             ref={terminalTiltRef}
-            className="card tilt-stage overflow-hidden shrink-0"
+            className="tilt-stage shrink-0"
           >
+            <div className="card overflow-hidden">
             <div
               className="tilt-layer flex items-center gap-2 border-b border-[var(--border)] pb-3 mb-4"
               style={{ transform: "translateZ(24px)" }}
@@ -174,6 +183,7 @@ export function AboutSection() {
               <span className="pill">AI/ML</span>
               <span className="pill">Cloud</span>
               <span className="pill">Leadership</span>
+            </div>
             </div>
           </div>
           </div>

--- a/next-portfolio/src/components/ContactSection.tsx
+++ b/next-portfolio/src/components/ContactSection.tsx
@@ -21,7 +21,7 @@ export function ContactSection() {
   const locationTilt = useMouseTilt<HTMLDivElement>({ max: 6, lift: 8, leaveMs: 400 });
 
   return (
-    <section id="contact" className="section-shell">
+    <section id="contact" className="section-shell" style={{ overflow: 'visible', contentVisibility: 'visible' }}>
       <div ref={reveal} className="reveal space-y-8">
         <SectionHeading
           tag="contact"
@@ -32,61 +32,67 @@ export function ContactSection() {
         {/* Contact cards grid */}
         <div
           className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
-          style={{ perspective: "1200px" }}
+          style={{ perspective: "1200px", overflow: "visible" }}
         >
           <Link
             href={`mailto:${personal.email}`}
             ref={emailTilt}
-            className="card card-glow tilt-stage flex items-center gap-4"
+            className="tilt-stage block"
           >
-            <div
-              className="tilt-layer flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-dim)]"
-              style={{ transform: "translateZ(22px)" }}
-            >
-              <MailIcon className="h-5 w-5 text-[var(--accent)]" />
-            </div>
-            <div className="tilt-layer min-w-0" style={{ transform: "translateZ(12px)" }}>
-              <p className="font-mono text-xs text-[var(--muted)]">{'// email'}</p>
-              <p className="truncate text-sm font-semibold text-[var(--text-strong)]">
-                {personal.email}
-              </p>
+            <div className="card card-glow flex items-center gap-4 h-full">
+              <div
+                className="tilt-layer flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-dim)]"
+                style={{ transform: "translateZ(22px)" }}
+              >
+                <MailIcon className="h-5 w-5 text-[var(--accent)]" />
+              </div>
+              <div className="tilt-layer min-w-0" style={{ transform: "translateZ(12px)" }}>
+                <p className="font-mono text-xs text-[var(--muted)]">{'// email'}</p>
+                <p className="truncate text-sm font-semibold text-[var(--text-strong)]">
+                  {personal.email}
+                </p>
+              </div>
             </div>
           </Link>
 
           <Link
             href={`tel:${socials.phone.replace(/\D/g, "")}`}
             ref={phoneTilt}
-            className="card card-glow tilt-stage flex items-center gap-4"
+            className="tilt-stage block"
           >
-            <div
-              className="tilt-layer flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-dim)]"
-              style={{ transform: "translateZ(22px)" }}
-            >
-              <PhoneIcon className="h-5 w-5 text-[var(--accent)]" />
-            </div>
-            <div className="tilt-layer" style={{ transform: "translateZ(12px)" }}>
-              <p className="font-mono text-xs text-[var(--muted)]">{'// phone'}</p>
-              <p className="text-sm font-semibold text-[var(--text-strong)]">
-                {socials.phone}
-              </p>
+            <div className="card card-glow flex items-center gap-4 h-full">
+              <div
+                className="tilt-layer flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-dim)]"
+                style={{ transform: "translateZ(22px)" }}
+              >
+                <PhoneIcon className="h-5 w-5 text-[var(--accent)]" />
+              </div>
+              <div className="tilt-layer" style={{ transform: "translateZ(12px)" }}>
+                <p className="font-mono text-xs text-[var(--muted)]">{'// phone'}</p>
+                <p className="text-sm font-semibold text-[var(--text-strong)]">
+                  {socials.phone}
+                </p>
+              </div>
             </div>
           </Link>
 
           <div
             ref={locationTilt}
-            className="card tilt-stage flex items-center gap-4"
+            className="tilt-stage"
           >
-            <div
-              className="tilt-layer flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-dim)]"
-              style={{ transform: "translateZ(22px)" }}
-            >
-              <LocationIcon className="h-5 w-5 text-[var(--accent)]" />
-            </div>
-            <div className="tilt-layer" style={{ transform: "translateZ(12px)" }}>
-              <p className="font-mono text-xs text-[var(--muted)]">{'// location'}</p>
-              <p className="text-sm font-semibold text-[var(--text-strong)]">
-                {personal.location}
-              </p>
+            <div className="card flex items-center gap-4">
+              <div
+                className="tilt-layer flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-dim)]"
+                style={{ transform: "translateZ(22px)" }}
+              >
+                <LocationIcon className="h-5 w-5 text-[var(--accent)]" />
+              </div>
+              <div className="tilt-layer" style={{ transform: "translateZ(12px)" }}>
+                <p className="font-mono text-xs text-[var(--muted)]">{'// location'}</p>
+                <p className="text-sm font-semibold text-[var(--text-strong)]">
+                  {personal.location}
+                </p>
+              </div>
             </div>
           </div>
         </div>

--- a/next-portfolio/src/components/EducationSection.tsx
+++ b/next-portfolio/src/components/EducationSection.tsx
@@ -11,7 +11,7 @@ export function EducationSection() {
   const tiltRef = useMouseTilt<HTMLElement>({ max: 6, lift: 9, leaveMs: 420 });
 
   return (
-    <section id="education" className="section-shell">
+    <section id="education" className="section-shell" style={{ overflow: 'visible', contentVisibility: 'visible' }}>
       <div ref={reveal} className="reveal space-y-8">
         <SectionHeading
           tag="education"
@@ -21,14 +21,15 @@ export function EducationSection() {
 
         <div
           className="reveal-stagger grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
-          style={{ perspective: "1200px" }}
+          style={{ perspective: "1200px", overflow: "visible" }}
         >
           {education.map((school) => (
             <article
               key={school.id}
               ref={tiltRef}
-              className="reveal card tilt-stage flex h-full flex-col border-l-4 border-l-[var(--accent)]"
+              className="reveal tilt-stage flex h-full flex-col"
             >
+              <div className="card border-l-4 border-l-[var(--accent)] flex h-full flex-col">
               <div
                 className="tilt-layer flex items-center gap-3"
                 style={{ transform: "translateZ(22px)" }}
@@ -66,6 +67,7 @@ export function EducationSection() {
                   </li>
                 ))}
               </ul>
+              </div>
             </article>
           ))}
         </div>

--- a/next-portfolio/src/components/ExperienceTimeline.tsx
+++ b/next-portfolio/src/components/ExperienceTimeline.tsx
@@ -11,7 +11,7 @@ export function ExperienceTimeline() {
   const tiltRef = useMouseTilt<HTMLElement>({ max: 5, lift: 8, leaveMs: 450 });
 
   return (
-    <section id="experience" className="section-shell">
+    <section id="experience" className="section-shell" style={{ overflow: 'visible', contentVisibility: 'visible' }}>
       <div>
         <SectionHeading
           tag="experience"
@@ -22,7 +22,7 @@ export function ExperienceTimeline() {
         <div ref={animateOnce}>
           <div
             className="relative pl-8 md:pl-12"
-            style={{ perspective: "1400px" }}
+            style={{ perspective: "1400px", overflow: "visible" }}
           >
             {/* Timeline line — centered at left-[11.5px] on mobile, left-[19.5px] on md */}
             <div className="absolute left-[11.5px] top-2 bottom-2 w-px bg-[var(--border)] md:left-[19.5px]" />
@@ -50,47 +50,49 @@ export function ExperienceTimeline() {
                   <article
                     data-animate-child
                     ref={tiltRef}
-                    className="card card-glow tilt-stage timeline-card-animate"
+                    className="tilt-stage timeline-card-animate"
                     style={{ animationDelay: `${index * 150 + 400}ms` }}
                   >
-                    <div
-                      className="tilt-layer flex items-start gap-4"
-                      style={{ transform: "translateZ(20px)" }}
-                    >
-                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--logo-bg)]">
-                        <Image
-                          src={`/${role.logo}`}
-                          alt={role.logoAlt}
-                          width={28}
-                          height={28}
-                          className="h-7 w-7 object-contain"
-                          style={{ filter: "var(--logo-filter)" }}
-                        />
+                    <div className="card card-glow">
+                      <div
+                        className="tilt-layer flex items-start gap-4"
+                        style={{ transform: "translateZ(20px)" }}
+                      >
+                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--logo-bg)]">
+                          <Image
+                            src={`/${role.logo}`}
+                            alt={role.logoAlt}
+                            width={28}
+                            height={28}
+                            className="h-7 w-7 object-contain"
+                            style={{ filter: "var(--logo-filter)" }}
+                          />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <h3 className="font-display text-lg font-bold tracking-tight text-[var(--text-strong)]">
+                            {role.title}
+                          </h3>
+                          <p className="text-sm font-medium text-[var(--muted-strong)]">
+                            {role.company}
+                          </p>
+                        </div>
                       </div>
-                      <div className="min-w-0 flex-1">
-                        <h3 className="font-display text-lg font-bold tracking-tight text-[var(--text-strong)]">
-                          {role.title}
-                        </h3>
-                        <p className="text-sm font-medium text-[var(--muted-strong)]">
-                          {role.company}
-                        </p>
-                      </div>
-                    </div>
 
-                    <ul
-                      className="tilt-layer mt-4 space-y-2 text-sm text-[var(--text)]"
-                      style={{ transform: "translateZ(8px)" }}
-                    >
-                      {role.responsibilities.map((item) => (
-                        <li
-                          key={item}
-                          className="flex gap-2 leading-relaxed"
-                        >
-                          <span className="mt-2 h-1 w-1 shrink-0 rounded-full bg-[var(--accent)]" />
-                          <span className="min-w-0">{item}</span>
-                        </li>
-                      ))}
-                    </ul>
+                      <ul
+                        className="tilt-layer mt-4 space-y-2 text-sm text-[var(--text)]"
+                        style={{ transform: "translateZ(8px)" }}
+                      >
+                        {role.responsibilities.map((item) => (
+                          <li
+                            key={item}
+                            className="flex gap-2 leading-relaxed"
+                          >
+                            <span className="mt-2 h-1 w-1 shrink-0 rounded-full bg-[var(--accent)]" />
+                            <span className="min-w-0">{item}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
                   </article>
                 </div>
               ))}

--- a/next-portfolio/src/components/FAQSection.tsx
+++ b/next-portfolio/src/components/FAQSection.tsx
@@ -9,7 +9,7 @@ export function FAQSection() {
   const reveal = useScrollReveal();
 
   return (
-    <section id="faq" className="section-shell">
+    <section id="faq" className="section-shell" style={{ overflow: 'visible', contentVisibility: 'visible' }}>
       <div ref={reveal} className="reveal space-y-6">
         <SectionHeading
           tag="faq"

--- a/next-portfolio/src/components/ProjectsGrid.tsx
+++ b/next-portfolio/src/components/ProjectsGrid.tsx
@@ -11,6 +11,7 @@ const formatTag = (tag: string): string => {
   const tagMap: Record<string, string> = {
     winner: "Winner",
     hackathon: "Hackathon",
+    ai: "AI",
   };
   return tagMap[tag] || tag;
 };
@@ -21,7 +22,7 @@ export function ProjectsGrid() {
   const tiltRef = useMouseTilt<HTMLElement>({ max: 7, lift: 10, leaveMs: 400 });
 
   return (
-    <section id="projects" className="section-shell">
+    <section id="projects" className="section-shell" style={{ overflow: 'visible', contentVisibility: 'visible' }}>
       <div className="space-y-8">
         <SectionHeading
           tag="projects"
@@ -32,16 +33,17 @@ export function ProjectsGrid() {
         <div
           ref={animateOnce as React.RefCallback<HTMLDivElement>}
           className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
-          style={{ perspective: "1200px" }}
+          style={{ perspective: "1200px", overflow: "visible" }}
         >
           {projects.map((project, index) => (
             <article
               key={project.id}
               data-animate-child
               ref={tiltRef}
-              className="card card-glow tilt-stage card-enter-animate flex h-full flex-col"
+              className="tilt-stage card-enter-animate"
               style={{ animationDelay: `${index * 100}ms` }}
             >
+              <div className="card card-glow flex h-full flex-col">
               <div
                 className="tilt-layer flex items-start justify-between gap-3"
                 style={{ transform: "translateZ(22px)" }}
@@ -84,6 +86,7 @@ export function ProjectsGrid() {
                   {project.linkText}
                   <ExternalIcon className="h-3.5 w-3.5" />
                 </Link>
+              </div>
               </div>
             </article>
           ))}

--- a/next-portfolio/src/components/SkillsSection.tsx
+++ b/next-portfolio/src/components/SkillsSection.tsx
@@ -79,7 +79,7 @@ export function SkillsSection() {
   const reveal = useScrollReveal();
 
   return (
-    <section id="skills" className="section-shell">
+    <section id="skills" className="section-shell" style={{ overflow: 'visible', contentVisibility: 'visible' }}>
       <div ref={reveal} className="reveal space-y-10">
         <SectionHeading
           tag="skills"

--- a/next-portfolio/src/data/projects.json
+++ b/next-portfolio/src/data/projects.json
@@ -14,7 +14,8 @@
     "description": "AI-powered repository intelligence platform leveraging RAG architecture with vector embeddings for semantic code search. Enables natural-language queries over codebases using LangChain and OpenAI models.",
     "techUsed": "Python, Flask, LangChain, OpenAI API, Elasticsearch, Next.js",
     "link": "https://github.com/elipaulman/Repo_Rover",
-    "linkText": "View Repo"
+    "linkText": "View Repo",
+    "tags": ["ai"]
   },
   {
     "id": "attendance-processor",

--- a/next-portfolio/src/hooks/useMouseTilt.ts
+++ b/next-portfolio/src/hooks/useMouseTilt.ts
@@ -49,6 +49,7 @@ export function useMouseTilt<T extends HTMLElement = HTMLElement>(
           window.clearTimeout(restoreTimer);
           restoreTimer = 0;
         }
+        node.style.willChange = "transform";
         node.style.transition = "transform 120ms ease-out";
       };
 
@@ -60,7 +61,7 @@ export function useMouseTilt<T extends HTMLElement = HTMLElement>(
         const ry = px * max * 2;
         if (raf) cancelAnimationFrame(raf);
         raf = requestAnimationFrame(() => {
-          node.style.transition = "";
+          node.style.transition = "none";
           node.style.transform = `rotateX(${rx}deg) rotateY(${ry}deg) translateZ(${lift}px)`;
         });
       };
@@ -74,6 +75,7 @@ export function useMouseTilt<T extends HTMLElement = HTMLElement>(
         node.style.transform = "";
         restoreTimer = window.setTimeout(() => {
           node.style.transition = "";
+          node.style.willChange = "";
           restoreTimer = 0;
         }, leaveMs);
       };


### PR DESCRIPTION
## Summary

- **Fix tilt lag** — `useMouseTilt` was clearing `transition` to `""` (empty string) on every animation frame, allowing the `.card` CSS class's `transition: transform 0.3s` to re-apply and make cards lag 300ms behind the cursor. Changed to `"none"` so the inline style always overrides during tracking.
- **Dynamic `will-change`** — Removed static `will-change: transform` from `.tilt-stage` CSS. Now set on `pointerenter` and cleared after the leave animation so the GPU compositing layer only exists during active hover, preventing it from clipping `box-shadow` at rest.
- **Fix glow clipping on edge cards** — Having `card` + `tilt-stage` on the same element caused `overflow: hidden` to override `transform-style: preserve-3d` per CSS spec, clipping glows at card/section boundaries. Separated into outer `tilt-stage` wrapper + inner `card` div across all affected sections (Projects, Experience, Education, Contact, About).
- **Section containment fix** — Added `contentVisibility: visible` and `overflow: visible` to all `section-shell` sections. `content-visibility: auto` implies `contain: layout` which makes overflow act like `clip`, cutting off card glows at section edges.
- **Grid overflow** — Added `overflow: visible` to all `perspective` grid containers.
- **RepoRover AI tag** — Added `"ai"` tag to RepoRover in `projects.json` and `"AI"` label to the `formatTag` map.