### PR TITLE
Redesign portfolio: terminal-inspired "Signal" visual identity

### DIFF
--- a/next-portfolio/src/app/globals.css
+++ b/next-portfolio/src/app/globals.css
@@ -2,90 +2,83 @@
 
 /* ───────────────────────── Dark theme (default) ───────────────────────── */
 :root {
-  --bg: #0a0a0f;
-  --bg-elevated: #141419;
-  --panel: rgba(10, 10, 15, 0.85);
-  --panel-hover: rgba(20, 20, 25, 0.9);
-  --panel-glass: linear-gradient(
-    135deg,
-    rgba(20, 20, 25, 0.9) 0%,
-    rgba(10, 10, 15, 0.85) 100%
-  );
+  --bg: #0c0e0c;
+  --bg-elevated: #191c17;
+  --panel: #141712;
+  --panel-hover: #191c17;
 
-  --border: rgba(255, 255, 255, 0.1);
-  --border-hover: rgba(255, 255, 255, 0.18);
-  --border-inner: rgba(255, 255, 255, 0.15);
+  --border: rgba(232, 230, 223, 0.13);
+  --border-hover: rgba(232, 230, 223, 0.22);
+  --border-inner: rgba(232, 230, 223, 0.07);
 
-  --text: #94a3b8;
-  --text-strong: #f1f5f9;
-  --muted: #64748b;
-  --muted-strong: #cbd5e1;
+  --text: #cfcdc4;
+  --text-strong: #e9e7df;
+  --muted: #8d9288;
+  --muted-strong: #a7ab9f;
 
-  --accent: #00e5a0;
-  --accent-dim: rgba(0, 229, 160, 0.08);
-  --accent-glow: rgba(0, 229, 160, 0.2);
-  --accent-2: #38bdf8;
-  --accent-2-dim: rgba(56, 189, 248, 0.08);
+  --accent: #dd934f;
+  --accent-dim: rgba(221, 147, 79, 0.1);
+  --accent-glow: rgba(221, 147, 79, 0.22);
+  --accent-2: #63a89d;
+  --accent-2-dim: rgba(99, 168, 157, 0.1);
+  --on-accent: #16130d;
 
-  --glow: 0 0 80px -15px rgba(0, 229, 160, 0.12);
-  --card-shadow: 
-    0 8px 32px rgba(0, 0, 0, 0.3),
+  --glow: 0 0 80px -15px rgba(221, 147, 79, 0.16);
+  --card-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.35),
     0 2px 8px rgba(0, 0, 0, 0.2),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1),
     0 0 0 1px var(--border);
   --logo-bg: rgba(255, 255, 255, 0.06);
   --logo-filter: invert(1) hue-rotate(180deg);
 
-  --line-number: rgba(255, 255, 255, 0.1);
-  --dot-color: rgba(255, 255, 255, 0.12);
-  --accent-rgb: 0, 229, 160;
+  --line-number: rgba(232, 230, 223, 0.1);
+  --accent-rgb: 221, 147, 79;
+  --accent-2-rgb: 99, 168, 157;
+  --ambient-op: 0.55;
   --line-duration: 1s;
 
   --font-mono: var(--font-jetbrains-mono), "Fira Code", "Cascadia Code", monospace;
-  --font-display: var(--font-syne), system-ui, sans-serif;
+  --font-display: var(--font-jetbrains-mono), "Fira Code", "Cascadia Code", monospace;
+  --font-serif: var(--font-source-serif), Charter, "Iowan Old Style", Georgia, serif;
 
   color-scheme: dark;
 }
 
 /* ───────────────────────── Light theme ───────────────────────── */
 :root[data-theme="light"] {
-  --bg: #f8fafb;
-  --bg-elevated: #ffffff;
-  --panel: rgba(255, 255, 255, 0.85);
-  --panel-hover: rgba(241, 245, 249, 0.95);
-  --panel-glass: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.95) 0%,
-    rgba(255, 255, 255, 0.85) 100%
-  );
+  --bg: #f5f3ec;
+  --bg-elevated: #eeece2;
+  --panel: #ffffff;
+  --panel-hover: #eeece2;
 
-  --border: rgba(15, 23, 42, 0.12);
-  --border-hover: rgba(15, 23, 42, 0.2);
-  --border-inner: rgba(255, 255, 255, 0.6);
+  --border: rgba(28, 31, 26, 0.13);
+  --border-hover: rgba(28, 31, 26, 0.24);
+  --border-inner: rgba(28, 31, 26, 0.07);
 
-  --text: #475569;
-  --text-strong: #0f172a;
-  --muted: #94a3b8;
-  --muted-strong: #334155;
+  --text: #33362e;
+  --text-strong: #1c1f1a;
+  --muted: #6b6f63;
+  --muted-strong: #52564a;
 
-  --accent: #059669;
-  --accent-dim: rgba(5, 150, 105, 0.06);
-  --accent-glow: rgba(5, 150, 105, 0.12);
-  --accent-2: #2563eb;
-  --accent-2-dim: rgba(37, 99, 235, 0.06);
+  --accent: #b5672a;
+  --accent-dim: rgba(181, 103, 42, 0.08);
+  --accent-glow: rgba(181, 103, 42, 0.16);
+  --accent-2: #2b756a;
+  --accent-2-dim: rgba(43, 117, 106, 0.08);
+  --on-accent: #fdf6ee;
 
-  --glow: 0 4px 40px -12px rgba(5, 150, 105, 0.1);
-  --card-shadow: 
-    0 8px 32px rgba(15, 23, 42, 0.08),
-    0 2px 8px rgba(15, 23, 42, 0.04),
-    inset 0 1px 0 rgba(255, 255, 255, 0.8),
+  --glow: 0 4px 40px -12px rgba(181, 103, 42, 0.14);
+  --card-shadow:
+    0 8px 24px rgba(28, 31, 26, 0.08),
+    0 2px 8px rgba(28, 31, 26, 0.04),
     0 0 0 1px var(--border);
   --logo-bg: rgba(15, 23, 42, 0.04);
   --logo-filter: none;
 
-  --line-number: rgba(15, 23, 42, 0.06);
-  --dot-color: rgba(15, 23, 42, 0.08);
-  --accent-rgb: 5, 150, 105;
+  --line-number: rgba(28, 31, 26, 0.08);
+  --accent-rgb: 181, 103, 42;
+  --accent-2-rgb: 43, 117, 106;
+  --ambient-op: 0.3;
   --line-duration: 1s;
 
   color-scheme: light;
@@ -93,20 +86,16 @@
 
 /* ───────────────────────── Tailwind v4 theme tokens ───────────────────────── */
 @theme inline {
-  --font-sans: var(--font-inter), system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
   --font-mono: var(--font-mono);
   --font-display: var(--font-display);
+  --font-serif: var(--font-serif);
 }
 
 /* ───────────────────────── Keyframes ───────────────────────── */
-@keyframes typing {
-  from { width: 0; }
-  to { width: var(--typing-width); }
-}
-
-@keyframes blink-caret {
-  from, to { border-color: transparent; }
-  50% { border-color: var(--accent); }
+@keyframes cursor-blink {
+  from, to { opacity: 1; }
+  50% { opacity: 0; }
 }
 
 @keyframes pulse-glow {
@@ -148,16 +137,6 @@
 @keyframes line-draw {
   from { transform: scaleY(0); }
   to   { transform: scaleY(1); }
-}
-
-@keyframes marquee-left {
-  from { transform: translateX(0); }
-  to   { transform: translateX(-50%); }
-}
-
-@keyframes marquee-right {
-  from { transform: translateX(-50%); }
-  to   { transform: translateX(0); }
 }
 
 /* ───────────────────────── Scroll-triggered child animations ───────────────────────── */
@@ -203,21 +182,60 @@
   transition: border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* ───────────────────────── Marquee ───────────────────────── */
-@media (hover: hover) {
-  .marquee-wrapper:hover .marquee-track {
-    animation-play-state: paused;
-  }
+/* ───────────────────────── Ambient background glow ───────────────────────── */
+.ambient-glow {
+  position: fixed;
+  inset: 0;
+  z-index: -10;
+  overflow: hidden;
+  pointer-events: none;
 }
 
-.marquee-wrapper .pill {
-  font-size: 0.85rem;
-  padding: 0.45rem 1.1rem;
-  letter-spacing: 0.01em;
+.ambient-glow span {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: var(--ambient-op, 0.5);
 }
 
-.marquee-track {
-  will-change: transform;
+.ambient-glow .a1 {
+  width: 620px;
+  height: 620px;
+  background: rgba(var(--accent-rgb), 0.11);
+  top: -220px;
+  left: -140px;
+  animation: drift1 28s ease-in-out infinite alternate;
+}
+
+.ambient-glow .a2 {
+  width: 520px;
+  height: 520px;
+  background: rgba(var(--accent-2-rgb), 0.1);
+  top: 15%;
+  right: -180px;
+  animation: drift2 34s ease-in-out infinite alternate;
+}
+
+.ambient-glow .a3 {
+  width: 460px;
+  height: 460px;
+  background: rgba(var(--accent-rgb), 0.06);
+  bottom: -140px;
+  left: 30%;
+  animation: drift3 40s ease-in-out infinite alternate;
+}
+
+@keyframes drift1 {
+  from { transform: translate(0, 0); }
+  to   { transform: translate(60px, 90px); }
+}
+@keyframes drift2 {
+  from { transform: translate(0, 0); }
+  to   { transform: translate(-70px, 40px); }
+}
+@keyframes drift3 {
+  from { transform: translate(0, 0); }
+  to   { transform: translate(40px, -60px); }
 }
 
 /* ───────────────────────── 3D tilt utilities ───────────────────────── */
@@ -267,18 +285,17 @@
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: 5rem;
   background: var(--bg);
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background:
-    radial-gradient(circle, var(--dot-color) 1px, transparent 1px) 0 0 / 24px 24px,
-    var(--bg);
+  background: var(--bg);
   color: var(--text);
-  font-family: var(--font-sans);
-  letter-spacing: -0.01em;
+  font-family: var(--font-serif);
+  letter-spacing: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -294,18 +311,33 @@ a {
 }
 
 /* ───────────────────────── Scrollbar ───────────────────────── */
+html {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--accent-rgb), 0.5) transparent;
+}
 ::-webkit-scrollbar {
-  width: 6px;
+  width: 11px;
 }
 ::-webkit-scrollbar-track {
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--accent) 25%, transparent);
+  background: linear-gradient(
+    180deg,
+    rgba(var(--accent-rgb), 0.55),
+    rgba(var(--accent-2-rgb), 0.5)
+  );
   border-radius: 999px;
+  border: 2px solid var(--bg);
+  background-clip: padding-box;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--accent) 40%, transparent);
+  background: linear-gradient(
+    180deg,
+    rgba(var(--accent-rgb), 0.85),
+    rgba(var(--accent-2-rgb), 0.75)
+  );
+  background-clip: padding-box;
 }
 
 /* ───────────────────────── Section shell ───────────────────────── */
@@ -359,37 +391,45 @@ a {
 /* ───────────────────────── Code tag markers ───────────────────────── */
 .code-tag {
   font-family: var(--font-mono);
-  font-size: 0.7rem;
+  font-size: 0.78rem;
   font-weight: 500;
   color: var(--muted);
-  letter-spacing: 0.06em;
+  letter-spacing: 0.04em;
   text-transform: lowercase;
 }
 
 .code-tag::before {
-  content: "<";
+  content: "// ";
   color: var(--accent);
 }
-.code-tag::after {
-  content: " />";
-  color: var(--accent);
+
+.section-divider {
+  height: 1px;
+  flex: 1;
+  max-width: 16rem;
+  background: linear-gradient(90deg, var(--accent), var(--border-inner) 70%);
+  transform-origin: left;
+  transform: scaleX(1);
+  transition: transform 0.9s cubic-bezier(0.16, 1, 0.3, 1) 0.15s;
+}
+
+.reveal:not(.revealed) .section-divider {
+  transform: scaleX(0);
 }
 
 /* ───────────────────────── Card ───────────────────────── */
 .card {
-  border-radius: 16px;
+  border-radius: 10px;
   border: 1px solid var(--border);
-  background: var(--panel-glass);
+  background: var(--panel);
   padding: 1.5rem;
   box-shadow: var(--card-shadow);
-  backdrop-filter: blur(20px) saturate(180%);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
   position: relative;
   overflow: hidden;
-  transition: 
-    border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-    transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition:
+    border-color 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .card::before {
@@ -412,45 +452,143 @@ a {
   border-color: var(--border-hover);
 }
 
+.card-glow {
+  --mx: 50%;
+  --my: 50%;
+}
+
+.card-glow::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  opacity: 0;
+  pointer-events: none;
+  background: radial-gradient(280px circle at var(--mx) var(--my), var(--accent-dim), transparent 60%);
+  transition: opacity 0.3s ease;
+}
+
 .card-glow:hover {
   border-color: color-mix(in srgb, var(--accent) 45%, transparent);
   box-shadow:
-    0 0 40px rgba(0, 229, 160, 0.15),
-    0 12px 40px rgba(0, 0, 0, 0.35),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 0 32px rgba(var(--accent-rgb), 0.14),
+    0 12px 32px rgba(0, 0, 0, 0.25),
     0 0 0 1px color-mix(in srgb, var(--accent) 25%, transparent);
 }
 
-/* ───────────────────────── Pill badge ───────────────────────── */
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  padding: 0.3rem 0.65rem;
-  border-radius: 8px;
-  background: var(--accent-dim);
-  border: 1px solid color-mix(in srgb, var(--accent) 18%, transparent);
-  color: var(--text-strong);
-  font-size: 0.75rem;
-  font-weight: 500;
-  font-family: var(--font-mono);
-  letter-spacing: 0.02em;
-  transition: 
-    background 0.25s cubic-bezier(0.4, 0, 0.2, 1),
-    border-color 0.25s cubic-bezier(0.4, 0, 0.2, 1),
-    transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-  white-space: nowrap;
-  backdrop-filter: blur(10px) saturate(150%);
-  -webkit-backdrop-filter: blur(10px) saturate(150%);
-  box-shadow: 
-    0 2px 8px rgba(0, 0, 0, 0.1),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+.card-glow:hover::after {
+  opacity: 1;
 }
 
-.pill:hover {
-  transform: scale(1.05);
-  box-shadow: 0 0 8px rgba(var(--accent-rgb), 0.4);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+.card-glow > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* ───────────────────────── Pill badge & buttons ─────────────────────────
+   Wrapped in @layer components so Tailwind's own utilities (hidden, flex,
+   md:hidden, etc.) — which Tailwind v4 emits inside @layer utilities — can
+   still override these when combined on the same element. Unlayered CSS
+   always beats @layer CSS regardless of source order or specificity, so
+   without this wrapper a plain `.icon-btn { display: inline-flex }` would
+   permanently defeat `md:hidden` on the same button. */
+@layer components {
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.3rem 0.65rem;
+    border-radius: 4px;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    color: var(--text-strong);
+    font-size: 0.75rem;
+    font-weight: 500;
+    font-family: var(--font-mono);
+    letter-spacing: 0.02em;
+    transition:
+      border-color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+      color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+      transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    white-space: nowrap;
+  }
+
+  .pill:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+    transform: translateY(-1px);
+    box-shadow: 0 0 10px rgba(var(--accent-rgb), 0.25);
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--panel);
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    padding: 0.6rem 1.1rem;
+    transition:
+      border-color 0.2s ease,
+      color 0.2s ease,
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
+  }
+
+  .btn:hover {
+    border-color: var(--border-hover);
+    color: var(--text-strong);
+    transform: translateY(-1px);
+  }
+
+  .btn:active {
+    transform: translateY(0);
+  }
+
+  .btn-ghost:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  .btn-primary {
+    border-color: var(--accent);
+    background: var(--accent);
+    color: var(--on-accent);
+    font-weight: 600;
+    animation: breathe 3.6s ease-in-out infinite;
+  }
+
+  .btn-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(var(--accent-rgb), 0.3);
+    animation-play-state: paused;
+  }
+
+  .icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--panel);
+    color: var(--muted);
+    padding: 0.6rem;
+    transition: border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  }
+
+  .icon-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+    transform: translateY(-1px);
+  }
+}
+
+@keyframes breathe {
+  0%, 100% { box-shadow: 0 0 0 rgba(var(--accent-rgb), 0); }
+  50% { box-shadow: 0 0 18px rgba(var(--accent-rgb), 0.3); }
 }
 
 /* ───────────────────────── Heading utility ───────────────────────── */
@@ -465,19 +603,15 @@ a {
 .typing-cursor::after {
   content: "|";
   display: inline;
-  animation: blink-caret 0.75s step-end infinite;
+  animation: cursor-blink 0.9s step-end infinite;
   color: var(--accent);
   font-weight: 300;
 }
 
-/* ───────────────────────── Line number gutter ───────────────────────── */
-.line-number-gutter {
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  color: var(--line-number);
-  user-select: none;
-  text-align: right;
-  line-height: 1.8;
+/* Solid (non-blinking) while text is still being typed out */
+.typing-cursor.is-typing::after {
+  animation: none;
+  opacity: 1;
 }
 
 /* ───────────────────────── Accent separator ───────────────────────── */
@@ -498,13 +632,13 @@ a {
 
   .app-bg-glow,
   .depth-grid,
-  .hero-glow-layer {
+  .hero-glow-layer,
+  .ambient-glow {
     display: none;
   }
 
   .hero-animate,
   .hero-subtitle,
-  .marquee-track,
   .timeline-dot-animate,
   .timeline-card-animate,
   .badge-animate,

--- a/next-portfolio/src/app/layout.tsx
+++ b/next-portfolio/src/app/layout.tsx
@@ -1,13 +1,7 @@
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono, Syne } from "next/font/google";
+import { JetBrains_Mono, Source_Serif_4 } from "next/font/google";
 import "./globals.css";
 import { personal, socials } from "@/lib/data";
-
-const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-inter",
-  display: "swap",
-});
 
 const jetBrainsMono = JetBrains_Mono({
   subsets: ["latin"],
@@ -15,9 +9,9 @@ const jetBrainsMono = JetBrains_Mono({
   display: "swap",
 });
 
-const syne = Syne({
+const sourceSerif = Source_Serif_4({
   subsets: ["latin"],
-  variable: "--font-syne",
+  variable: "--font-source-serif",
   display: "swap",
 });
 
@@ -101,7 +95,7 @@ export default function RootLayout({
           }}
         />
       </head>
-      <body className={`${inter.variable} ${jetBrainsMono.variable} ${syne.variable} bg-[var(--bg)] text-[var(--text)] antialiased`}>
+      <body className={`${jetBrainsMono.variable} ${sourceSerif.variable} bg-[var(--bg)] text-[var(--text)] antialiased`}>
         {children}
       </body>
     </html>

--- a/next-portfolio/src/app/page.tsx
+++ b/next-portfolio/src/app/page.tsx
@@ -37,8 +37,12 @@ export default function Home() {
   return (
     <>
       <div className="relative min-h-screen">
-        {/* Subtle accent gradient at top */}
-        <div className="app-bg-glow pointer-events-none absolute inset-x-0 top-0 -z-10 h-[70vh] bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,var(--accent-dim),transparent)]" />
+        {/* Slow-drifting ambient glow, fixed behind the whole page */}
+        <div className="ambient-glow app-bg-glow" aria-hidden="true">
+          <span className="a1" />
+          <span className="a2" />
+          <span className="a3" />
+        </div>
 
         <NavBar resumePath={socials.resume.path} />
         <main className="mx-auto max-w-5xl px-5 pb-14 sm:px-8 sm:pb-16">

--- a/next-portfolio/src/components/AboutSection.tsx
+++ b/next-portfolio/src/components/AboutSection.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 import { personal, socials } from "@/lib/data";
 import { SectionHeading } from "./SectionHeading";
 import { useScrollReveal } from "@/hooks/useScrollReveal";
@@ -26,13 +27,13 @@ export function AboutSection() {
         />
 
         <div
-          className="grid gap-8 lg:grid-cols-2 lg:items-stretch"
+          className="grid gap-8 lg:grid-cols-2 lg:items-start"
           style={{ perspective: "1400px", overflow: "visible" }}
         >
           {/* Bio */}
           <div className="flex flex-col gap-6">
-            <div ref={tiltRef} className="tilt-stage flex-1">
-              <div className="card h-full">
+            <div ref={tiltRef} className="tilt-stage">
+              <div className="card">
               <p
                 className="tilt-layer leading-relaxed text-[var(--text)]"
                 style={{ transform: "translateZ(10px)" }}
@@ -48,75 +49,28 @@ export function AboutSection() {
               </div>
             </div>
 
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div ref={tiltRef} className="tilt-stage">
-                <div className="card">
-                <p
-                  className="tilt-layer font-mono text-xs text-[var(--accent)]"
-                  style={{ transform: "translateZ(14px)" }}
-                >
-                  {'// focus'}
-                </p>
-                <p
-                  className="tilt-layer mt-2 font-display text-sm font-semibold tracking-tight text-[var(--text-strong)]"
-                  style={{ transform: "translateZ(20px)" }}
-                >
-                  What I focus on
-                </p>
-                <p
-                  className="tilt-layer mt-1 text-sm text-[var(--muted)]"
-                  style={{ transform: "translateZ(8px)" }}
-                >
-                  Quality engineering, test automation, and building AI/ML-powered products with measurable impact.
-                </p>
-                </div>
-              </div>
-              <div ref={tiltRef} className="tilt-stage">
-                <div className="card">
-                <p
-                  className="tilt-layer font-mono text-xs text-[var(--accent)]"
-                  style={{ transform: "translateZ(14px)" }}
-                >
-                  {'// method'}
-                </p>
-                <p
-                  className="tilt-layer mt-2 font-display text-sm font-semibold tracking-tight text-[var(--text-strong)]"
-                  style={{ transform: "translateZ(20px)" }}
-                >
-                  How I work
-                </p>
-                <p
-                  className="tilt-layer mt-1 text-sm text-[var(--muted)]"
-                  style={{ transform: "translateZ(8px)" }}
-                >
-                  Bias for action, fast iterations, clean API boundaries, and crisp documentation.
-                </p>
-                </div>
-              </div>
-            </div>
+            <StatsRow />
           </div>
 
-          {/* Photo + Terminal column */}
-          <div className="flex flex-col gap-4 h-full">
-          {/* Photo card */}
-          <div ref={photoTiltRef} className="tilt-stage flex-1 min-h-96">
-            <div className="card overflow-hidden p-2 h-full">
-            <div className="relative h-full min-h-48 rounded-lg overflow-hidden">
+          {/* Photo + Terminal facts column */}
+          <div className="flex flex-col gap-4">
+          <div ref={photoTiltRef} className="tilt-stage">
+            <div className="card overflow-hidden p-2">
+            <div className="relative h-56 rounded-lg overflow-hidden sm:h-64">
               <Image
                 src="/images/eli-photo-1-optimized.jpg"
                 alt="Elijah Paulman at an Apple campus event"
                 fill
-                className="object-cover object-[center_82%]"
+                className="object-cover object-[center_65%]"
                 sizes="(max-width: 640px) calc(100vw - 3rem), (max-width: 1024px) 90vw, 440px"
               />
             </div>
             </div>
           </div>
 
-          {/* Terminal card */}
           <div
             ref={terminalTiltRef}
-            className="tilt-stage shrink-0"
+            className="tilt-stage"
           >
             <div className="card overflow-hidden">
             <div
@@ -173,16 +127,10 @@ export function AboutSection() {
                 }
               />
               <TerminalRow label="location" value={personal.location} />
-            </div>
-
-            <div
-              className="tilt-layer mt-6 flex flex-wrap gap-2"
-              style={{ transform: "translateZ(18px)" }}
-            >
-              <span className="pill">Full-stack</span>
-              <span className="pill">AI/ML</span>
-              <span className="pill">Cloud</span>
-              <span className="pill">Leadership</span>
+              <TerminalRow
+                label="status"
+                value={<span className="text-[var(--accent)]">full-time @ Apple</span>}
+              />
             </div>
             </div>
           </div>
@@ -190,6 +138,70 @@ export function AboutSection() {
         </div>
       </div>
     </section>
+  );
+}
+
+function StatsRow() {
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+      {personal.stats.map((stat) => (
+        <Stat key={stat.label} {...stat} />
+      ))}
+    </div>
+  );
+}
+
+function Stat({
+  value,
+  suffix,
+  label,
+}: {
+  value: number;
+  suffix: string;
+  label: string;
+}) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [display, setDisplay] = useState("0");
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const format = (n: number) =>
+      (n >= 1000 ? n.toLocaleString("en-US") : String(n)) + suffix;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          observer.disconnect();
+          const duration = 1400;
+          const start = performance.now();
+          const step = (now: number) => {
+            const progress = Math.min((now - start) / duration, 1);
+            const eased = 1 - Math.pow(1 - progress, 3);
+            setDisplay(format(Math.floor(value * eased)));
+            if (progress < 1) requestAnimationFrame(step);
+          };
+          requestAnimationFrame(step);
+        });
+      },
+      { threshold: 0.5 }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [value, suffix]);
+
+  return (
+    <div className="border-l-2 border-[var(--border)] pl-3 transition-colors duration-200 hover:border-[var(--accent)]">
+      <span
+        ref={ref}
+        className="block font-mono text-2xl font-semibold tabular-nums text-[var(--accent)]"
+      >
+        {display}
+      </span>
+      <span className="mt-1 block text-xs text-[var(--muted)]">{label}</span>
+    </div>
   );
 }
 

--- a/next-portfolio/src/components/ContactSection.tsx
+++ b/next-portfolio/src/components/ContactSection.tsx
@@ -3,107 +3,33 @@
 import Link from "next/link";
 import { personal, socials } from "@/lib/data";
 import { SectionHeading } from "./SectionHeading";
-import {
-  DownloadIcon,
-  GitHubIcon,
-  LinkedInIcon,
-  MailIcon,
-  PhoneIcon,
-  LocationIcon,
-} from "./icons";
+import { DownloadIcon, GitHubIcon, LinkedInIcon } from "./icons";
 import { useScrollReveal } from "@/hooks/useScrollReveal";
-import { useMouseTilt } from "@/hooks/useMouseTilt";
 
 export function ContactSection() {
   const reveal = useScrollReveal();
-  const emailTilt = useMouseTilt<HTMLAnchorElement>({ max: 8, lift: 10, leaveMs: 400 });
-  const phoneTilt = useMouseTilt<HTMLAnchorElement>({ max: 8, lift: 10, leaveMs: 400 });
-  const locationTilt = useMouseTilt<HTMLDivElement>({ max: 6, lift: 8, leaveMs: 400 });
 
   return (
     <section id="contact" className="section-shell" style={{ overflow: 'visible', contentVisibility: 'visible' }}>
-      <div ref={reveal} className="reveal space-y-8">
+      <div ref={reveal} className="reveal space-y-6">
         <SectionHeading
           tag="contact"
           title="Let's Build Something"
           description="I'm most responsive via email and LinkedIn."
         />
 
-        {/* Contact cards grid */}
-        <div
-          className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
-          style={{ perspective: "1200px", overflow: "visible" }}
-        >
-          <Link
-            href={`mailto:${personal.email}`}
-            ref={emailTilt}
-            className="tilt-stage block"
-          >
-            <div className="card card-glow flex items-center gap-4 h-full">
-              <div
-                className="tilt-layer flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-dim)]"
-                style={{ transform: "translateZ(22px)" }}
-              >
-                <MailIcon className="h-5 w-5 text-[var(--accent)]" />
-              </div>
-              <div className="tilt-layer min-w-0" style={{ transform: "translateZ(12px)" }}>
-                <p className="font-mono text-xs text-[var(--muted)]">{'// email'}</p>
-                <p className="truncate text-sm font-semibold text-[var(--text-strong)]">
-                  {personal.email}
-                </p>
-              </div>
-            </div>
-          </Link>
-
-          <Link
-            href={`tel:${socials.phone.replace(/\D/g, "")}`}
-            ref={phoneTilt}
-            className="tilt-stage block"
-          >
-            <div className="card card-glow flex items-center gap-4 h-full">
-              <div
-                className="tilt-layer flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-dim)]"
-                style={{ transform: "translateZ(22px)" }}
-              >
-                <PhoneIcon className="h-5 w-5 text-[var(--accent)]" />
-              </div>
-              <div className="tilt-layer" style={{ transform: "translateZ(12px)" }}>
-                <p className="font-mono text-xs text-[var(--muted)]">{'// phone'}</p>
-                <p className="text-sm font-semibold text-[var(--text-strong)]">
-                  {socials.phone}
-                </p>
-              </div>
-            </div>
-          </Link>
-
-          <div
-            ref={locationTilt}
-            className="tilt-stage"
-          >
-            <div className="card flex items-center gap-4">
-              <div
-                className="tilt-layer flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-dim)]"
-                style={{ transform: "translateZ(22px)" }}
-              >
-                <LocationIcon className="h-5 w-5 text-[var(--accent)]" />
-              </div>
-              <div className="tilt-layer" style={{ transform: "translateZ(12px)" }}>
-                <p className="font-mono text-xs text-[var(--muted)]">{'// location'}</p>
-                <p className="text-sm font-semibold text-[var(--text-strong)]">
-                  {personal.location}
-                </p>
-              </div>
-            </div>
-          </div>
+        <div className="card max-w-xl space-y-2.5 font-mono text-sm">
+          <Row label="email" value={personal.email} href={`mailto:${personal.email}`} />
+          <Row label="phone" value={socials.phone} href={`tel:${socials.phone.replace(/\D/g, "")}`} />
+          <Row label="location" value={personal.location} />
         </div>
 
-        {/* Social + Resume row */}
-        <div className="flex flex-wrap items-center justify-center gap-3 sm:justify-start">
+        <div className="flex flex-wrap items-center gap-3">
           <Link
             href={socials.socialMedia.linkedin.url}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--panel)] px-4 py-2.5 font-mono text-sm text-[var(--muted)] backdrop-blur-xl backdrop-saturate-180 shadow-[0_4px_16px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all duration-300 hover:border-[var(--accent)] hover:text-[var(--accent)] hover:shadow-[0_0_24px_var(--accent-glow),0_4px_16px_rgba(0,229,160,0.12)] hover:scale-[1.02]"
+            className="btn btn-ghost px-4 py-2.5 text-sm"
           >
             <LinkedInIcon className="h-4 w-4" />
             linkedin
@@ -112,7 +38,7 @@ export function ContactSection() {
             href={socials.socialMedia.github.url}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--panel)] px-4 py-2.5 font-mono text-sm text-[var(--muted)] backdrop-blur-xl backdrop-saturate-180 shadow-[0_4px_16px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all duration-300 hover:border-[var(--accent)] hover:text-[var(--accent)] hover:shadow-[0_0_24px_var(--accent-glow),0_4px_16px_rgba(0,229,160,0.12)] hover:scale-[1.02]"
+            className="btn btn-ghost px-4 py-2.5 text-sm"
           >
             <GitHubIcon className="h-4 w-4" />
             github
@@ -120,7 +46,7 @@ export function ContactSection() {
           <Link
             href={socials.resume.path}
             download
-            className="inline-flex items-center gap-2 rounded-xl border border-[var(--accent)] bg-[var(--accent-dim)] px-4 py-2.5 font-mono text-sm font-semibold text-[var(--text-strong)] backdrop-blur-xl backdrop-saturate-180 shadow-[0_4px_16px_rgba(0,229,160,0.12),inset_0_1px_0_rgba(255,255,255,0.1)] transition-all duration-300 hover:shadow-[0_0_32px_var(--accent-glow),0_4px_16px_rgba(0,229,160,0.2)] hover:scale-[1.02]"
+            className="btn btn-primary px-4 py-2.5 text-sm"
           >
             <DownloadIcon className="h-4 w-4" />
             &gt; download resume.pdf
@@ -128,5 +54,29 @@ export function ContactSection() {
         </div>
       </div>
     </section>
+  );
+}
+
+function Row({
+  label,
+  value,
+  href,
+}: {
+  label: string;
+  value: string;
+  href?: string;
+}) {
+  return (
+    <div className="flex gap-2">
+      <span className="shrink-0 text-[var(--accent)]">{label}</span>
+      <span className="text-[var(--muted)]">=</span>
+      {href ? (
+        <Link href={href} className="min-w-0 truncate text-[var(--text-strong)] hover:text-[var(--accent)]">
+          {value}
+        </Link>
+      ) : (
+        <span className="min-w-0 truncate text-[var(--text-strong)]">{value}</span>
+      )}
+    </div>
   );
 }

--- a/next-portfolio/src/components/ExperienceTimeline.tsx
+++ b/next-portfolio/src/components/ExperienceTimeline.tsx
@@ -3,101 +3,59 @@
 import Image from "next/image";
 import { experience } from "@/lib/data";
 import { SectionHeading } from "./SectionHeading";
-import { useAnimateOnce } from "@/hooks/useScrollReveal";
-import { useMouseTilt } from "@/hooks/useMouseTilt";
+import { useScrollReveal } from "@/hooks/useScrollReveal";
 
 export function ExperienceTimeline() {
-  const animateOnce = useAnimateOnce();
-  const tiltRef = useMouseTilt<HTMLElement>({ max: 5, lift: 8, leaveMs: 450 });
+  const reveal = useScrollReveal();
 
   return (
     <section id="experience" className="section-shell" style={{ overflow: 'visible', contentVisibility: 'visible' }}>
-      <div>
+      <div ref={reveal} className="reveal">
         <SectionHeading
-          tag="experience"
+          tag="experience --log --all"
           title="Building & Shipping"
           description="Full-time roles, internships, and achievements that taught me how to ship quickly, lead teams, and own outcomes."
         />
 
-        <div ref={animateOnce}>
-          <div
-            className="relative pl-8 md:pl-12"
-            style={{ perspective: "1400px", overflow: "visible" }}
-          >
-            {/* Timeline line — centered at left-[11.5px] on mobile, left-[19.5px] on md */}
-            <div className="absolute left-[11.5px] top-2 bottom-2 w-px bg-[var(--border)] md:left-[19.5px]" />
+        <div>
+          {experience.map((role) => (
             <div
-              data-animate-child
-              className="accent-line-draw absolute left-[11.5px] top-2 bottom-2 w-px bg-[var(--accent)] opacity-60 md:left-[19.5px]"
-            />
-
-            <div className="space-y-6">
-              {experience.map((role, index) => (
-                <div key={role.id} className="relative">
-                  {/* Timeline dot — centered on line, vertically centered with date */}
-                  <div
-                    data-animate-child
-                    className="timeline-dot-animate absolute left-[-25px] top-[3px] h-2.5 w-2.5 rounded-full border-2 border-[var(--accent)] bg-[var(--bg)] md:left-[-33px]"
-                    style={{ animationDelay: `${index * 200 + 300}ms` }}
+              key={role.id}
+              className="grid grid-cols-1 gap-3 border-b border-[var(--border-inner)] py-4 sm:grid-cols-[118px_1fr] sm:gap-5 last:border-b-0"
+            >
+              <p className="font-mono text-xs text-[var(--accent-2)] sm:pt-0.5">
+                {role.date}
+              </p>
+              <div className="flex min-w-0 gap-3.5">
+                <span className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--logo-bg)] p-2">
+                  <Image
+                    src={`/${role.logo}`}
+                    alt={role.logoAlt}
+                    width={40}
+                    height={40}
+                    className="h-full w-full object-contain"
+                    style={{ filter: "var(--logo-filter)" }}
                   />
-
-                  {/* Date */}
-                  <p className="mb-2 font-mono text-xs leading-[18px] text-[var(--muted)]">
-                    {role.date}
+                </span>
+                <div className="min-w-0">
+                  <p className="text-base font-semibold text-[var(--text-strong)]">
+                    {role.title}
                   </p>
-
-                  {/* Card */}
-                  <article
-                    data-animate-child
-                    ref={tiltRef}
-                    className="tilt-stage timeline-card-animate"
-                    style={{ animationDelay: `${index * 150 + 400}ms` }}
-                  >
-                    <div className="card card-glow">
-                      <div
-                        className="tilt-layer flex items-start gap-4"
-                        style={{ transform: "translateZ(20px)" }}
+                  <p className="mb-2.5 text-sm text-[var(--muted)]">{role.company}</p>
+                  <div className="space-y-1.5">
+                    {role.responsibilities.map((item) => (
+                      <p
+                        key={item}
+                        className="max-w-[75ch] text-sm leading-relaxed text-[var(--muted)]"
                       >
-                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--logo-bg)]">
-                          <Image
-                            src={`/${role.logo}`}
-                            alt={role.logoAlt}
-                            width={28}
-                            height={28}
-                            className="h-7 w-7 object-contain"
-                            style={{ filter: "var(--logo-filter)" }}
-                          />
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          <h3 className="font-display text-lg font-bold tracking-tight text-[var(--text-strong)]">
-                            {role.title}
-                          </h3>
-                          <p className="text-sm font-medium text-[var(--muted-strong)]">
-                            {role.company}
-                          </p>
-                        </div>
-                      </div>
-
-                      <ul
-                        className="tilt-layer mt-4 space-y-2 text-sm text-[var(--text)]"
-                        style={{ transform: "translateZ(8px)" }}
-                      >
-                        {role.responsibilities.map((item) => (
-                          <li
-                            key={item}
-                            className="flex gap-2 leading-relaxed"
-                          >
-                            <span className="mt-2 h-1 w-1 shrink-0 rounded-full bg-[var(--accent)]" />
-                            <span className="min-w-0">{item}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  </article>
+                        {item}
+                      </p>
+                    ))}
+                  </div>
                 </div>
-              ))}
+              </div>
             </div>
-          </div>
+          ))}
         </div>
       </div>
     </section>

--- a/next-portfolio/src/components/Hero.tsx
+++ b/next-portfolio/src/components/Hero.tsx
@@ -1,29 +1,33 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useState } from "react";
 import { personal } from "@/lib/data";
 import type { Socials } from "@/types";
 import { GitHubIcon, LinkedInIcon, MailIcon, DocumentIcon } from "./icons";
 import { useMouseTilt } from "@/hooks/useMouseTilt";
+import { useTypewriterLoop } from "@/hooks/useTypewriterLoop";
+import { useTypewriterOnce } from "@/hooks/useTypewriterOnce";
 
 type HeroProps = {
   socials: Socials;
 };
 
-export function Hero({ socials }: HeroProps) {
-  const [showCursor, setShowCursor] = useState(true);
-  const tiltRef = useMouseTilt<HTMLDivElement>({ max: 5, lift: 6, leaveMs: 550 });
+const EYEBROW_COMMANDS = [
+  "whoami",
+  "cat about.md",
+  "ls experience/",
+  "git log --oneline -3",
+];
 
-  useEffect(() => {
-    const timer = setTimeout(() => setShowCursor(false), 4000);
-    return () => clearTimeout(timer);
-  }, []);
+const HEADLINE = `${personal.name} builds carrier\nsystems at Apple`;
+
+export function Hero({ socials }: HeroProps) {
+  const tiltRef = useMouseTilt<HTMLDivElement>({ max: 5, lift: 6, leaveMs: 550 });
+  const eyebrow = useTypewriterLoop(EYEBROW_COMMANDS);
+  const { text: headline, done: headlineDone } = useTypewriterOnce(HEADLINE, 650);
 
   return (
     <section id="intro" className="relative py-24 sm:py-32 lg:py-40">
-      {/* Background glow layers */}
       <div
         aria-hidden="true"
         className="hero-glow-layer"
@@ -37,51 +41,27 @@ export function Hero({ socials }: HeroProps) {
           animation: "hero-glow-pulse 4s ease-in-out infinite alternate",
         }}
       />
-      <div
-        aria-hidden="true"
-        className="hero-glow-layer"
-        style={{
-          position: "absolute",
-          inset: 0,
-          pointerEvents: "none",
-          zIndex: 0,
-          background:
-            "radial-gradient(ellipse 40% 40% at 80% 80%, rgba(var(--accent-rgb), 0.04) 0%, transparent 60%)",
-          animation: "hero-glow-pulse 6s ease-in-out infinite alternate-reverse",
-        }}
-      />
 
       <div className="tilt-perspective relative" style={{ zIndex: 1 }}>
-        <div
-          ref={tiltRef}
-          className="tilt-stage space-y-8 text-center sm:text-left"
-          style={{ position: "relative" }}
-        >
+        <div ref={tiltRef} className="tilt-stage space-y-6" style={{ position: "relative" }}>
           <div aria-hidden="true" className="depth-grid" />
-          {/* Avatar + greeting */}
+
+          {/* Terminal eyebrow */}
           <div
-            className="hero-animate tilt-layer flex items-center justify-center gap-4 sm:justify-start"
+            className="hero-animate tilt-layer"
             style={{
               transform: "translateZ(18px)",
               animation: "fade-slide-up 0.6s 100ms ease-out both",
             }}
           >
-            <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-full ring-[1.5px] ring-[var(--accent)] ring-offset-2 ring-offset-[var(--bg)]">
-              <Image
-                src="/images/EliStandingClear-avatar.png"
-                alt="Elijah Paulman"
-                fill
-                className="object-cover object-top"
-                sizes="56px"
-                priority
-              />
-            </div>
-            <p className="font-mono text-xs tracking-wide text-[var(--accent)]">
-              {'// hello, I\'m'}
+            <p className="min-h-[1.2em] font-mono text-xs tracking-wide text-[var(--accent)]" aria-hidden="true">
+              {"$ "}
+              {eyebrow}
+              <span className="typing-cursor" />
             </p>
           </div>
 
-          {/* Name */}
+          {/* Narrative headline */}
           <div
             className="hero-animate tilt-layer"
             style={{
@@ -89,36 +69,46 @@ export function Hero({ socials }: HeroProps) {
               animation: "fade-slide-up 0.6s 250ms ease-out both",
             }}
           >
-            <h1 className="heading-display text-5xl text-[var(--text-strong)] sm:text-6xl lg:text-7xl xl:text-8xl">
-              {personal.name}
+            <h1
+              className="min-h-[2.3em] font-mono font-semibold text-[var(--text-strong)] sm:min-h-[2.28em]"
+              style={{
+                fontSize: "clamp(2rem, 5vw, 3.4rem)",
+                lineHeight: 1.14,
+                letterSpacing: "-0.015em",
+              }}
+            >
+              {headline.split("\n").map((line, i) => (
+                <span key={i}>
+                  {i > 0 && <br />}
+                  {line}
+                </span>
+              ))}
+              <span className={`typing-cursor${headlineDone ? "" : " is-typing"}`} />
             </h1>
           </div>
 
-          {/* Typing subtitle */}
+          {/* Lede */}
           <div
-            className="hero-animate tilt-layer flex justify-center overflow-hidden sm:justify-start"
+            className="hero-animate tilt-layer"
             style={{
               transform: "translateZ(12px)",
               animation: "fade-slide-up 0.6s 400ms ease-out both",
             }}
           >
             <p
-              className={`hero-subtitle inline-block overflow-hidden whitespace-nowrap border-r-2 border-[var(--accent)] font-mono text-sm text-[var(--muted)] sm:text-base ${
-                !showCursor ? "border-transparent" : ""
-              }`}
-              style={{
-                "--typing-width": `${personal.title.length}ch`,
-                animation: `typing 3s steps(${personal.title.length}, end) forwards, blink-caret 0.75s step-end 5`,
-                width: "0",
-              } as React.CSSProperties}
+              className="max-w-[60ch] text-[var(--text)]"
+              style={{ fontSize: "1.1rem", lineHeight: 1.68 }}
             >
-              {personal.title}
+              Software Quality Engineer testing and automating{" "}
+              <span className="text-[var(--accent-2)]">iPhone carrier onboarding</span>. Ohio
+              State CSE &apos;25. Previously shipped automation at Amazon and REST APIs at
+              London Computer Systems.
             </p>
           </div>
 
           {/* CTA buttons */}
           <div
-            className="hero-animate tilt-layer flex flex-wrap items-center justify-center gap-3 pt-4 sm:justify-start"
+            className="hero-animate tilt-layer flex flex-wrap items-center gap-3 pt-2"
             style={{
               transform: "translateZ(28px)",
               animation: "fade-slide-up 0.6s 550ms ease-out both",
@@ -126,7 +116,7 @@ export function Hero({ socials }: HeroProps) {
           >
             <Link
               href={`mailto:${socials.email.primary}`}
-              className="inline-flex items-center gap-2 rounded-xl border border-[var(--accent)] bg-[var(--accent-dim)] px-5 py-2.5 font-mono text-sm font-medium text-[var(--text-strong)] backdrop-blur-xl backdrop-saturate-180 shadow-[0_4px_16px_rgba(0,229,160,0.12),inset_0_1px_0_rgba(255,255,255,0.1)] transition-all duration-300 hover:shadow-[0_0_32px_var(--accent-glow),0_4px_16px_rgba(0,229,160,0.2)] hover:border-[var(--accent)] hover:scale-[1.02]"
+              className="btn btn-primary px-5 py-2.5 text-sm"
             >
               <MailIcon className="h-4 w-4" />
               contact me
@@ -134,7 +124,7 @@ export function Hero({ socials }: HeroProps) {
             <Link
               href={socials.resume.path}
               download
-              className="inline-flex items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--panel)] px-5 py-2.5 font-mono text-sm text-[var(--muted)] backdrop-blur-xl backdrop-saturate-180 shadow-[0_4px_16px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all duration-300 hover:border-[var(--border-hover)] hover:text-[var(--text-strong)] hover:shadow-[0_8px_24px_rgba(0,0,0,0.12)] hover:scale-[1.02]"
+              className="btn px-5 py-2.5 text-sm"
             >
               <DocumentIcon className="h-4 w-4" />
               resume.pdf
@@ -147,7 +137,7 @@ export function Hero({ socials }: HeroProps) {
                 href={socials.socialMedia.github.url}
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--panel)] p-2.5 text-[var(--muted)] backdrop-blur-xl backdrop-saturate-180 shadow-[0_4px_16px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all duration-300 hover:border-[var(--border-hover)] hover:text-[var(--text-strong)] hover:shadow-[0_8px_24px_rgba(0,0,0,0.12)] hover:scale-[1.05]"
+                className="icon-btn"
                 aria-label="GitHub"
               >
                 <GitHubIcon className="h-4 w-4" />
@@ -156,7 +146,7 @@ export function Hero({ socials }: HeroProps) {
                 href={socials.socialMedia.linkedin.url}
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--panel)] p-2.5 text-[var(--muted)] backdrop-blur-xl backdrop-saturate-180 shadow-[0_4px_16px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all duration-300 hover:border-[var(--border-hover)] hover:text-[var(--text-strong)] hover:shadow-[0_8px_24px_rgba(0,0,0,0.12)] hover:scale-[1.05]"
+                className="icon-btn"
                 aria-label="LinkedIn"
               >
                 <LinkedInIcon className="h-4 w-4" />

--- a/next-portfolio/src/components/NavBar.tsx
+++ b/next-portfolio/src/components/NavBar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { ThemeToggle } from "./ThemeToggle";
 import { DownloadIcon } from "./icons";
+import { useScrollSpy } from "@/hooks/useScrollSpy";
 
 const links = [
   { href: "#about", label: "about" },
@@ -15,11 +16,14 @@ const links = [
   { href: "#contact", label: "contact" },
 ];
 
+const sectionIds = links.map((link) => link.href.slice(1));
+
 export function NavBar({ resumePath }: { resumePath: string }) {
   const [open, setOpen] = useState(false);
+  const activeId = useScrollSpy(sectionIds);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-[var(--border)] bg-[var(--bg)]/70 backdrop-blur-xl backdrop-saturate-180 shadow-[0_8px_32px_rgba(0,0,0,0.12)]">
+    <header className="sticky top-0 z-50 border-b border-[var(--border)] bg-[var(--bg)]/85">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-5 py-3 sm:px-8">
         <Link
           href="#intro"
@@ -29,29 +33,36 @@ export function NavBar({ resumePath }: { resumePath: string }) {
         </Link>
 
         <nav className="hidden items-center gap-0.5 md:flex">
-          {links.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="relative rounded-md px-3 py-1.5 font-mono text-[0.7rem] text-[var(--muted)] transition-colors duration-200 hover:text-[var(--text-strong)]"
-            >
-              {link.label}
-            </Link>
-          ))}
+          {links.map((link) => {
+            const isActive = activeId === link.href.slice(1);
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`relative rounded-md px-3 py-1.5 font-mono text-[0.7rem] transition-colors duration-200 after:absolute after:inset-x-3 after:-bottom-px after:h-px after:bg-[var(--accent)] after:transition-transform after:duration-200 after:content-[''] hover:text-[var(--text-strong)] ${
+                  isActive
+                    ? "text-[var(--text-strong)] after:scale-x-100"
+                    : "text-[var(--muted)] after:scale-x-0"
+                }`}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
         </nav>
 
         <div className="flex items-center gap-2">
           <Link
             href={resumePath}
             download
-            className="hidden items-center gap-1.5 rounded-xl border border-[var(--border)] bg-[var(--panel)] px-3 py-1.5 font-mono text-[0.7rem] text-[var(--muted)] backdrop-blur-xl backdrop-saturate-180 shadow-[0_2px_8px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all duration-300 hover:border-[var(--border-hover)] hover:text-[var(--text-strong)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.12)] hover:scale-[1.05] md:inline-flex"
+            className="btn btn-primary hidden h-9 text-[0.7rem] px-3 py-0 md:inline-flex"
           >
             <DownloadIcon className="h-3.5 w-3.5" />
             resume
           </Link>
           <ThemeToggle />
           <button
-            className="rounded-xl border border-[var(--border)] bg-[var(--panel)] px-3 py-2 font-mono text-xs text-[var(--muted)] backdrop-blur-xl backdrop-saturate-180 shadow-[0_2px_8px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all duration-300 hover:border-[var(--border-hover)] hover:text-[var(--text-strong)] hover:scale-[1.05] md:hidden"
+            className="icon-btn h-9 font-mono text-[0.7rem] px-3 py-0 md:hidden"
             onClick={() => setOpen((p) => !p)}
             aria-label="Toggle navigation"
             aria-expanded={open}
@@ -61,17 +72,26 @@ export function NavBar({ resumePath }: { resumePath: string }) {
         </div>
       </div>
 
-      {open && (
-        <nav className="border-t border-[var(--border)] px-5 py-4 sm:px-8 md:hidden backdrop-blur-xl">
-          <div className="space-y-1">
+      <div
+        className="grid md:hidden"
+        aria-hidden={!open}
+        inert={!open}
+        style={{
+          gridTemplateRows: open ? "1fr" : "0fr",
+          opacity: open ? 1 : 0,
+          transition: "grid-template-rows 200ms ease-out, opacity 160ms ease-out",
+        }}
+      >
+        <nav className="overflow-hidden">
+          <div className="space-y-1 border-t border-[var(--border)] px-5 py-4 sm:px-8">
             {links.map((link) => (
               <Link
                 key={link.href}
                 href={link.href}
                 onClick={() => setOpen(false)}
-                className="block rounded-xl px-4 py-2.5 font-mono text-sm text-[var(--muted)] backdrop-blur-sm bg-[var(--panel)]/50 border border-transparent shadow-[0_2px_8px_rgba(0,0,0,0.04)] transition-all duration-200 hover:bg-[var(--panel-hover)] hover:border-[var(--border)] hover:text-[var(--text-strong)] hover:shadow-[0_4px_12px_rgba(0,0,0,0.08)]"
+                className="block rounded-md px-4 py-2.5 font-mono text-sm text-[var(--muted)] border border-transparent transition-all duration-200 hover:bg-[var(--panel-hover)] hover:border-[var(--border)] hover:text-[var(--text-strong)]"
               >
-                <span className="text-[var(--accent)] opacity-50">{'// '}</span>
+                <span className="text-[var(--accent)] opacity-70">{'// '}</span>
                 {link.label}
               </Link>
             ))}
@@ -79,14 +99,14 @@ export function NavBar({ resumePath }: { resumePath: string }) {
               href={resumePath}
               download
               onClick={() => setOpen(false)}
-              className="flex items-center gap-2 rounded-xl px-4 py-2.5 font-mono text-sm text-[var(--muted)] backdrop-blur-sm bg-[var(--panel)]/50 border border-transparent shadow-[0_2px_8px_rgba(0,0,0,0.04)] transition-all duration-200 hover:bg-[var(--panel-hover)] hover:border-[var(--border)] hover:text-[var(--text-strong)] hover:shadow-[0_4px_12px_rgba(0,0,0,0.08)]"
+              className="flex items-center gap-2 rounded-md px-4 py-2.5 font-mono text-sm text-[var(--muted)] border border-transparent transition-all duration-200 hover:bg-[var(--panel-hover)] hover:border-[var(--border)] hover:text-[var(--text-strong)]"
             >
               <DownloadIcon className="h-3.5 w-3.5" />
               resume.pdf
             </Link>
           </div>
         </nav>
-      )}
+      </div>
     </header>
   );
 }

--- a/next-portfolio/src/components/ProjectsGrid.tsx
+++ b/next-portfolio/src/components/ProjectsGrid.tsx
@@ -5,7 +5,8 @@ import { projects, socials } from "@/lib/data";
 import { SectionHeading } from "./SectionHeading";
 import { ExternalIcon } from "./icons";
 import { useAnimateOnce } from "@/hooks/useScrollReveal";
-import { useMouseTilt } from "@/hooks/useMouseTilt";
+import { useGroupTilt } from "@/hooks/useGroupTilt";
+import { mergeRefs } from "@/lib/mergeRefs";
 
 const formatTag = (tag: string): string => {
   const tagMap: Record<string, string> = {
@@ -19,7 +20,7 @@ const formatTag = (tag: string): string => {
 export function ProjectsGrid() {
   const githubReposLink = socials.socialMedia.github.url;
   const animateOnce = useAnimateOnce();
-  const tiltRef = useMouseTilt<HTMLElement>({ max: 7, lift: 10, leaveMs: 400 });
+  const groupTilt = useGroupTilt<HTMLDivElement>({ liftPx: 4, radiusPx: 260, leaveMs: 400 });
 
   return (
     <section id="projects" className="section-shell" style={{ overflow: 'visible', contentVisibility: 'visible' }}>
@@ -31,7 +32,7 @@ export function ProjectsGrid() {
         />
 
         <div
-          ref={animateOnce as React.RefCallback<HTMLDivElement>}
+          ref={mergeRefs(animateOnce as React.RefCallback<HTMLDivElement>, groupTilt)}
           className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
           style={{ perspective: "1200px", overflow: "visible" }}
         >
@@ -39,7 +40,7 @@ export function ProjectsGrid() {
             <article
               key={project.id}
               data-animate-child
-              ref={tiltRef}
+              data-group-tilt-card
               className="tilt-stage card-enter-animate"
               style={{ animationDelay: `${index * 100}ms` }}
             >
@@ -96,7 +97,7 @@ export function ProjectsGrid() {
           href={githubReposLink}
           target="_blank"
           rel="noreferrer"
-          className="block rounded-xl border border-[var(--accent)] bg-[var(--accent-dim)] px-5 py-4 text-center font-mono text-sm font-medium text-[var(--text-strong)] backdrop-blur-xl backdrop-saturate-180 shadow-[0_4px_16px_rgba(0,229,160,0.12),inset_0_1px_0_rgba(255,255,255,0.1)] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[0_0_40px_var(--accent-glow),0_4px_16px_rgba(0,229,160,0.2)]"
+          className="btn btn-primary block px-5 py-4 text-center text-sm justify-center"
         >
           &gt; View all projects on GitHub
         </Link>

--- a/next-portfolio/src/components/SectionHeading.tsx
+++ b/next-portfolio/src/components/SectionHeading.tsx
@@ -6,13 +6,16 @@ type SectionHeadingProps = {
 
 export function SectionHeading({ tag, title, description }: SectionHeadingProps) {
   return (
-    <div className="mb-12 space-y-4 text-center sm:text-left">
-      <span className="code-tag">{tag}</span>
-      <h2 className="heading-display pb-2 text-3xl leading-normal text-[var(--text-strong)] sm:text-4xl lg:text-5xl">
+    <div className="mb-10 space-y-2 text-left">
+      <div className="flex items-center gap-4">
+        <span className="code-tag shrink-0">{tag}</span>
+        <div className="section-divider" />
+      </div>
+      <h2 className="heading-display text-xl font-semibold tracking-tight text-[var(--text-strong)] sm:text-2xl">
         {title}
       </h2>
       {description && (
-        <p className="mx-auto max-w-2xl text-base leading-relaxed text-[var(--muted)] sm:mx-0">
+        <p className="max-w-2xl text-sm leading-relaxed text-[var(--muted)]">
           {description}
         </p>
       )}

--- a/next-portfolio/src/components/SkillsSection.tsx
+++ b/next-portfolio/src/components/SkillsSection.tsx
@@ -5,73 +5,38 @@ import { SectionHeading } from "./SectionHeading";
 import { useScrollReveal } from "@/hooks/useScrollReveal";
 
 const categories = [
-  { key: "programmingLanguages" as const, label: "languages", reverse: false },
-  { key: "frameworks" as const, label: "frameworks", reverse: true },
-  { key: "tools" as const, label: "tools", reverse: false },
-  { key: "skills" as const, label: "specialties", reverse: true },
+  { key: "programmingLanguages" as const, label: "languages" },
+  { key: "frameworks" as const, label: "frameworks" },
+  { key: "tools" as const, label: "tools" },
+  { key: "skills" as const, label: "specialties" },
 ];
 
-function MarqueeRow({
+function SkillCard({
   label,
   items,
-  reverse,
-  duration,
 }: {
   label: string;
   items: { name: string }[];
-  reverse: boolean;
-  duration: number;
 }) {
-  const doubled = [...items, ...items];
-
   return (
-    <>
-      <div className="card overflow-hidden md:hidden">
-        <div className="mb-4 border-b border-[var(--border)] pb-3">
-          <p className="font-mono text-xs font-medium tracking-wide text-[var(--accent)]">
-            {"// "}
-            {label}
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {items.map((item) => (
-            <span
-              key={item.name}
-              className="pill cursor-default select-none whitespace-nowrap"
-            >
-              {item.name}
-            </span>
-          ))}
-        </div>
+    <div className="card h-full">
+      <div className="mb-4 border-b border-[var(--border)] pb-3">
+        <p className="font-mono text-xs font-medium tracking-wide text-[var(--accent)]">
+          {"// "}
+          {label}
+        </p>
       </div>
-      <div className="marquee-wrapper relative hidden overflow-hidden py-1 md:block">
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-20"
-          style={{ background: "linear-gradient(90deg, var(--bg) 0%, transparent 100%)" }}
-        />
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-20"
-          style={{ background: "linear-gradient(270deg, var(--bg) 0%, transparent 100%)" }}
-        />
-        <div
-          className="marquee-track flex w-max gap-5"
-          style={{
-            animation: `${reverse ? "marquee-right" : "marquee-left"} ${duration}s linear infinite`,
-          }}
-        >
-          {doubled.map((item, idx) => (
-            <span
-              key={`${item.name}-${idx}`}
-              className="pill cursor-default select-none whitespace-nowrap"
-            >
-              {item.name}
-            </span>
-          ))}
-        </div>
+      <div className="flex flex-wrap gap-2">
+        {items.map((item) => (
+          <span
+            key={item.name}
+            className="pill cursor-default select-none whitespace-nowrap"
+          >
+            {item.name}
+          </span>
+        ))}
       </div>
-    </>
+    </div>
   );
 }
 
@@ -80,29 +45,16 @@ export function SkillsSection() {
 
   return (
     <section id="skills" className="section-shell" style={{ overflow: 'visible', contentVisibility: 'visible' }}>
-      <div ref={reveal} className="reveal space-y-10">
+      <div ref={reveal} className="reveal space-y-8">
         <SectionHeading
           tag="skills"
           title="Stacks I Build With"
-          description="Languages, frameworks, platforms, and specialties I rely on to ship production-grade software."
+          description="Languages, frameworks, platforms, and specialties I rely on to ship production-grade software — including Claude Code and AI-assisted development in my day-to-day workflow."
         />
-        <div className="space-y-7">
+        <div className="grid gap-4 sm:grid-cols-2">
           {categories.map((cat) => {
             const items = skills[cat.key] ?? [];
-            return (
-              <div key={cat.key}>
-                <p className="mb-3 hidden font-mono text-sm font-medium text-[var(--accent)] md:block">
-                  {"// "}
-                  {cat.label}
-                </p>
-                <MarqueeRow
-                  label={cat.label}
-                  items={items}
-                  reverse={cat.reverse}
-                  duration={Math.round(items.length * 4)}
-                />
-              </div>
-            );
+            return <SkillCard key={cat.key} label={cat.label} items={items} />;
           })}
         </div>
       </div>

--- a/next-portfolio/src/components/ThemeToggle.tsx
+++ b/next-portfolio/src/components/ThemeToggle.tsx
@@ -40,7 +40,7 @@ export function ThemeToggle() {
     <button
       type="button"
       onClick={toggleTheme}
-      className="flex items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--panel)] px-3 py-1.5 font-mono text-[0.7rem] text-[var(--muted)] backdrop-blur-xl backdrop-saturate-180 shadow-[0_2px_8px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all duration-300 hover:border-[var(--border-hover)] hover:text-[var(--text-strong)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.12)] hover:scale-[1.05]"
+      className="btn h-9 font-mono text-[0.7rem] px-3 py-0"
       aria-label="Toggle theme"
     >
       {theme === "dark" ? (

--- a/next-portfolio/src/data/education.json
+++ b/next-portfolio/src/data/education.json
@@ -16,13 +16,13 @@
   {
     "id": "sinclair",
     "institution": "Sinclair Community College",
-    "degree": "A.S. Liberal Arts and Sciences",
+    "degree": "A.S. Liberal Arts and Sciences — dual enrollment",
     "dates": "August 2020 - May 2022",
     "image": "images/testimonials/SinclairLogo.jpg",
     "imageAlt": "Sinclair Community College",
     "details": [
-      "4.0 GPA",
-      "50 CCP credits",
+      "Completed concurrently with high school via Ohio's College Credit Plus program",
+      "4.0 GPA, 50 CCP credits",
       "Dean's List 2021-2022"
     ]
   },

--- a/next-portfolio/src/data/faq.json
+++ b/next-portfolio/src/data/faq.json
@@ -4,7 +4,7 @@
     "question": "What are your technical skills?",
     "answer": {
       "programmingLanguages": "Java, C#, Python, TypeScript, JavaScript, C, SQL, HTML, CSS, x86 Assembly",
-      "software": "Git/GitHub, VS Code, AWS (Lambda, AppSync, S3), MongoDB, MySQL, Postman, Visual Studio, Firebase, Elasticsearch, MATLAB, Microsoft Office, Google Workspace, SolidWorks",
+      "software": "Git/GitHub, Claude Code, VS Code, AWS (Lambda, AppSync, S3), MongoDB, MySQL, Postman, Visual Studio, Firebase, Elasticsearch, MATLAB, Microsoft Office, Google Workspace, SolidWorks",
       "frameworks": "React, Vue.js, Node.js, Express, Next.js, Flask, LangChain, Tailwind CSS, .NET",
       "otherSkills": "REST & GraphQL APIs, Machine Learning, Computer Vision, CI/CD, Data Structures & Algorithms, Agile Development, Test-Driven Development, Technical Documentation, Full Stack Development, IoT (ESP32), electronic and computer hardware, circuit assembly, 3D printing"
     },

--- a/next-portfolio/src/data/personal.json
+++ b/next-portfolio/src/data/personal.json
@@ -16,5 +16,11 @@
     "short": "I'm a Software Quality Engineer at Apple, where I work on the carrier services that power iPhone activation. I graduated from Ohio State (CSE, December 2025) and love shipping production systems — I've built them at Amazon and London Computer Systems, focusing on automation and scalable architecture.",
     "detailed": "At Apple, I test and automate carrier onboarding workflows for iPhone. At Amazon, I automated catalog systems managing 13,000+ items with 60% efficiency gains. At LCS, I built REST APIs serving 100,000+ users. I'm passionate about AI/ML — I've developed AI-powered apps with LangChain, led 20+ engineers as ESW President, and won multiple J.P. Morgan hackathons."
   },
-  "hobbies": "I enjoy playing guitar, mountain biking, skiing, kayaking, and spending time with friends and family. I also love tinkering — whether that's creating projects on my 3D printer, building with Arduino, or working on bikes and fixing things with my hands."
+  "hobbies": "I enjoy playing guitar, mountain biking, skiing, kayaking, and spending time with friends and family. I also love tinkering — whether that's creating projects on my 3D printer, building with Arduino, or working on bikes and fixing things with my hands.",
+  "stats": [
+    { "value": 13000, "suffix": "+", "label": "catalog items automated" },
+    { "value": 60, "suffix": "%", "label": "manual effort reduced" },
+    { "value": 100000, "suffix": "+", "label": "users served (LCS APIs)" },
+    { "value": 20, "suffix": "+", "label": "engineers led at ESW" }
+  ]
 }

--- a/next-portfolio/src/data/skills.json
+++ b/next-portfolio/src/data/skills.json
@@ -31,9 +31,11 @@
     { "name": "Visual Studio" },
     { "name": "VS Code" },
     { "name": "MATLAB" },
-    { "name": "Splunk" }
+    { "name": "Splunk" },
+    { "name": "Claude Code" }
   ],
   "skills": [
+    { "name": "AI-Assisted Development" },
     { "name": "Machine Learning" },
     { "name": "Computer Vision" },
     { "name": "CI/CD" },

--- a/next-portfolio/src/hooks/useGroupTilt.ts
+++ b/next-portfolio/src/hooks/useGroupTilt.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useCallback, type RefCallback } from "react";
+
+export interface UseGroupTiltOptions {
+  liftPx?: number;
+  radiusPx?: number;
+  leaveMs?: number;
+}
+
+/**
+ * Gives every `[data-group-tilt-card]` descendant a gentle, distance-based
+ * lift toward the cursor as it moves across the container, so the grid
+ * reads as one responsive surface rather than isolated hover targets.
+ * Deliberately avoids 3D rotation — it read as disorienting in practice.
+ */
+export function useGroupTilt<T extends HTMLElement = HTMLElement>(
+  options: UseGroupTiltOptions = {}
+): RefCallback<T> {
+  const { liftPx = 4, radiusPx = 260, leaveMs = 400 } = options;
+
+  return useCallback(
+    (node: T | null) => {
+      if (!node || typeof window === "undefined") return;
+
+      const supportsHover = window.matchMedia(
+        "(hover: hover) and (pointer: fine)"
+      ).matches;
+      const isSmallViewport = window.matchMedia("(max-width: 768px)").matches;
+      if (!supportsHover || isSmallViewport) return;
+
+      let raf = 0;
+      let restoreTimer = 0;
+
+      const cards = () =>
+        Array.from(node.querySelectorAll<HTMLElement>("[data-group-tilt-card]"));
+
+      const handleMove = (e: PointerEvent) => {
+        if (restoreTimer) {
+          window.clearTimeout(restoreTimer);
+          restoreTimer = 0;
+        }
+        if (raf) cancelAnimationFrame(raf);
+        raf = requestAnimationFrame(() => {
+          cards().forEach((card) => {
+            const rect = card.getBoundingClientRect();
+            const cx = rect.left + rect.width / 2;
+            const cy = rect.top + rect.height / 2;
+            const dist = Math.hypot(e.clientX - cx, e.clientY - cy);
+            const proximity = clamp(1 - dist / radiusPx, 0, 1);
+
+            card.style.transition = "transform 220ms ease-out";
+            card.style.transform = `translateY(${-proximity * liftPx}px)`;
+
+            if (
+              e.clientX >= rect.left &&
+              e.clientX <= rect.right &&
+              e.clientY >= rect.top &&
+              e.clientY <= rect.bottom
+            ) {
+              card.style.setProperty(
+                "--mx",
+                `${((e.clientX - rect.left) / rect.width) * 100}%`
+              );
+              card.style.setProperty(
+                "--my",
+                `${((e.clientY - rect.top) / rect.height) * 100}%`
+              );
+            }
+          });
+        });
+      };
+
+      const handleLeave = () => {
+        if (raf) {
+          cancelAnimationFrame(raf);
+          raf = 0;
+        }
+        cards().forEach((card) => {
+          card.style.transition = `transform ${leaveMs}ms cubic-bezier(0.16, 1, 0.3, 1)`;
+          card.style.transform = "";
+        });
+        restoreTimer = window.setTimeout(() => {
+          cards().forEach((card) => {
+            card.style.transition = "";
+          });
+          restoreTimer = 0;
+        }, leaveMs);
+      };
+
+      node.addEventListener("pointermove", handleMove);
+      node.addEventListener("pointerleave", handleLeave);
+    },
+    [liftPx, radiusPx, leaveMs]
+  );
+}
+
+function clamp(n: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, n));
+}

--- a/next-portfolio/src/hooks/useMouseTilt.ts
+++ b/next-portfolio/src/hooks/useMouseTilt.ts
@@ -63,6 +63,8 @@ export function useMouseTilt<T extends HTMLElement = HTMLElement>(
         raf = requestAnimationFrame(() => {
           node.style.transition = "none";
           node.style.transform = `rotateX(${rx}deg) rotateY(${ry}deg) translateZ(${lift}px)`;
+          node.style.setProperty("--mx", `${(px + 0.5) * 100}%`);
+          node.style.setProperty("--my", `${(py + 0.5) * 100}%`);
         });
       };
 

--- a/next-portfolio/src/hooks/useScrollSpy.ts
+++ b/next-portfolio/src/hooks/useScrollSpy.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useScrollSpy(ids: string[]): string | null {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const sections = ids
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (sections.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: "-40% 0px -50% 0px", threshold: 0 }
+    );
+
+    sections.forEach((section) => observer.observe(section));
+    return () => observer.disconnect();
+  }, [ids]);
+
+  return activeId;
+}

--- a/next-portfolio/src/hooks/useTypewriterLoop.ts
+++ b/next-portfolio/src/hooks/useTypewriterLoop.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useTypewriterLoop(commands: string[]): string {
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    if (commands.length === 0) return;
+
+    let commandIndex = 0;
+    let charIndex = 0;
+    let deleting = false;
+    let timer = 0;
+
+    const step = () => {
+      const full = commands[commandIndex];
+      if (!deleting) {
+        charIndex++;
+        setText(full.slice(0, charIndex));
+        if (charIndex === full.length) {
+          deleting = true;
+          timer = window.setTimeout(step, 1600);
+          return;
+        }
+        timer = window.setTimeout(step, 46);
+      } else {
+        charIndex--;
+        setText(full.slice(0, charIndex));
+        if (charIndex === 0) {
+          deleting = false;
+          commandIndex = (commandIndex + 1) % commands.length;
+          timer = window.setTimeout(step, 380);
+          return;
+        }
+        timer = window.setTimeout(step, 26);
+      }
+    };
+
+    timer = window.setTimeout(step, 300);
+    return () => window.clearTimeout(timer);
+  }, [commands]);
+
+  return text;
+}

--- a/next-portfolio/src/hooks/useTypewriterOnce.ts
+++ b/next-portfolio/src/hooks/useTypewriterOnce.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/** Types out `text` once, character by character, starting after `delayMs`. */
+export function useTypewriterOnce(
+  text: string,
+  delayMs = 0
+): { text: string; done: boolean } {
+  const [length, setLength] = useState(0);
+
+  useEffect(() => {
+    let i = 0;
+    let timer = 0;
+
+    const step = () => {
+      i++;
+      setLength(i);
+      if (i < text.length) {
+        timer = window.setTimeout(step, 38);
+      }
+    };
+
+    timer = window.setTimeout(step, delayMs);
+    return () => window.clearTimeout(timer);
+  }, [text, delayMs]);
+
+  return { text: text.slice(0, length), done: length >= text.length };
+}

--- a/next-portfolio/src/lib/mergeRefs.ts
+++ b/next-portfolio/src/lib/mergeRefs.ts
@@ -1,0 +1,14 @@
+import type { RefCallback, Ref } from "react";
+
+export function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
+  return (node: T | null) => {
+    refs.forEach((ref) => {
+      if (!ref) return;
+      if (typeof ref === "function") {
+        ref(node);
+      } else {
+        (ref as { current: T | null }).current = node;
+      }
+    });
+  };
+}

--- a/next-portfolio/src/types.ts
+++ b/next-portfolio/src/types.ts
@@ -17,6 +17,11 @@ export type Personal = {
     detailed: string;
   };
   hobbies: string;
+  stats: {
+    value: number;
+    suffix: string;
+    label: string;
+  }[];
 };
 
 export type SocialMediaLink = {


### PR DESCRIPTION
## Summary
- Replaces the glassmorphic dark green/blue theme with a flatter, terminal-inspired amber/teal palette (`--accent`/`--accent-2`) across both light and dark modes
- Swaps Inter/Syne for a monospace-headline + serif-body pairing (JetBrains Mono + Source Serif 4)
- Rebuilds Hero (typewriter eyebrow + narrative headline), Experience (flat log-row list with company logo badges), Contact (compact terminal key/value block), and SectionHeading (compact `// label` style) to match the new aesthetic instead of just re-skinning the old layouts
- Adds scrollspy nav, count-up stats in About, cursor-spotlight + shared "group tilt" on project cards, ambient background glow, and a custom scrollbar
- Fixes a real Tailwind v4 cascade-layer bug: custom `.btn`/`.icon-btn`/`.pill` classes were unlayered CSS, which always beats `@layer utilities` regardless of source order — this silently broke `md:hidden`/`md:flex` and left the mobile hamburger menu visible at desktop widths
- Adds `scroll-padding-top` so anchored nav links no longer land flush under the sticky header
- Data/content fixes: Claude Code + AI-assisted development called out in Skills and FAQ, Sinclair Community College now notes dual enrollment via Ohio's College Credit Plus, About's status line reads "full-time @ Apple" instead of implying availability

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Manually verified via dev server: all sections render, dark/light toggle works, mobile nav opens/closes and no longer bleeds onto desktop, nav scrollspy tracks section, hero typewriter/cursor behave correctly
- [ ] Recommend a manual pass on an actual phone/tablet before merging (I don't have a live browser in this environment to screenshot from)