### PR TITLE
Fix About photo cropping head off in landscape/wide layouts

### DIFF
--- a/next-portfolio/src/components/AboutSection.tsx
+++ b/next-portfolio/src/components/AboutSection.tsx
@@ -54,9 +54,9 @@ export function AboutSection() {
 
           {/* Photo + Terminal facts column */}
           <div className="flex flex-col gap-4">
-          <div ref={photoTiltRef} className="tilt-stage">
+          <div ref={photoTiltRef} className="tilt-stage mx-auto w-full max-w-md lg:max-w-none">
             <div className="card overflow-hidden p-2">
-            <div className="relative h-56 rounded-lg overflow-hidden sm:h-64">
+            <div className="relative aspect-[4/3] w-full rounded-lg overflow-hidden">
               <Image
                 src="/images/eli-photo-1-optimized.jpg"
                 alt="Elijah Paulman at an Apple campus event"


### PR DESCRIPTION
## Summary
- Follow-up to #16: on wide single-column layouts (notably iPhone landscape), the About section's photo card used a fixed pixel height regardless of container width, so `object-cover` had to scale the image up much further to fill the width — shrinking the visible vertical slice and cropping the subject's head off
- Switched the photo container from a fixed `h-56/h-64` to an `aspect-[4/3]` box so height scales proportionally with width, and capped the card's max width below the two-column breakpoint so it doesn't stretch to an extreme wide/short crop box on landscape phones

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Verified fresh dev server serves the updated markup
- [ ] Recommend a quick visual check on an actual iPhone in landscape before merging